### PR TITLE
feat: Roslyn MSBuild loader, Location helper, isolated test assets, xUnit v3 migration

### DIFF
--- a/src/CdIndex.Emit/CdIndex.Emit.csproj
+++ b/src/CdIndex.Emit/CdIndex.Emit.csproj
@@ -7,5 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../CdIndex.Core/CdIndex.Core.csproj" />
+    <PackageReference Include="Humanizer.Core" Version="2.14.1" />
   </ItemGroup>
 </Project>

--- a/src/CdIndex.Roslyn/CdIndex.Roslyn.csproj
+++ b/src/CdIndex.Roslyn/CdIndex.Roslyn.csproj
@@ -8,5 +8,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.*" />
   </ItemGroup>
 </Project>

--- a/src/CdIndex.Roslyn/LocationUtil.cs
+++ b/src/CdIndex.Roslyn/LocationUtil.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis;
+using System.IO;
+
+namespace CdIndex.Roslyn;
+
+public static class LocationUtil
+{
+    public static (string Path, int Line) GetLocation(SyntaxNode node, RoslynContext ctx)
+    {
+        var span = node.GetLocation().GetLineSpan();
+        var absPath = span.Path.Replace("\\", "/");
+        var relPath = absPath.Replace(ctx.RepoRoot.Replace("\\", "/"), "").TrimStart('/');
+        var line = span.StartLinePosition.Line + 1;
+        return (relPath, line);
+    }
+}

--- a/src/CdIndex.Roslyn/MsBuildBootstrap.cs
+++ b/src/CdIndex.Roslyn/MsBuildBootstrap.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using Microsoft.Build.Locator;
+
+namespace CdIndex.Roslyn;
+
+public static class MsBuildBootstrap
+{
+    private static int _registered;
+    public static void EnsureRegistered()
+    {
+        if (Interlocked.Exchange(ref _registered, 1) == 1)
+            return;
+        if (!MSBuildLocator.IsRegistered)
+        {
+            try
+            {
+                MSBuildLocator.RegisterDefaults();
+            }
+            catch (Exception ex)
+            {
+                throw new InvalidOperationException("MSBuild SDK not found. Проверь global.json / setup-dotnet.", ex);
+            }
+        }
+    }
+}

--- a/src/CdIndex.Roslyn/RoslynContext.cs
+++ b/src/CdIndex.Roslyn/RoslynContext.cs
@@ -1,0 +1,49 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace CdIndex.Roslyn;
+
+public sealed class RoslynContext
+{
+    public MSBuildWorkspace Workspace { get; }
+    public Solution Solution { get; }
+    public IReadOnlyDictionary<ProjectId, Compilation> Compilations { get; }
+    public string RepoRoot { get; }
+
+    public RoslynContext(
+        MSBuildWorkspace workspace,
+        Solution solution,
+        IReadOnlyDictionary<ProjectId, Compilation> compilations,
+        string repoRoot)
+    {
+        Workspace = workspace;
+        Solution = solution;
+        Compilations = compilations;
+        RepoRoot = repoRoot;
+    }
+
+    public Document? FindDocument(SyntaxTree tree)
+    {
+        foreach (var project in Solution.Projects)
+        {
+            var doc = project.Documents.FirstOrDefault(d => d.TryGetSyntaxTree(out var t) && t == tree);
+            if (doc is not null) return doc;
+        }
+        return null;
+    }
+
+    public async Task<SemanticModel> GetSemanticModelAsync(Document doc, CancellationToken ct)
+    {
+        if (!doc.SupportsSyntaxTree)
+            throw new InvalidOperationException($"Document '{doc.FilePath ?? doc.Name}' does not support a syntax tree.");
+
+        if (!doc.Project.SupportsCompilation)
+            throw new InvalidOperationException($"Project '{doc.Project.Name}' does not support compilation.");
+
+        var model = await doc.GetSemanticModelAsync(ct).ConfigureAwait(false);
+        if (model is null)
+            throw new InvalidOperationException($"Failed to obtain SemanticModel for '{doc.FilePath ?? doc.Name}'.");
+
+        return model;
+    }
+}

--- a/src/CdIndex.Roslyn/SolutionLoader.cs
+++ b/src/CdIndex.Roslyn/SolutionLoader.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.MSBuild;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CdIndex.Roslyn;
+
+public static class SolutionLoader
+{
+    public static async Task<RoslynContext> LoadSolutionAsync(string slnPath, string repoRoot, CancellationToken ct = default)
+    {
+        MsBuildBootstrap.EnsureRegistered();
+        var workspace = MSBuildWorkspace.Create();
+        var solution = await workspace.OpenSolutionAsync(slnPath, cancellationToken: ct);
+        var compilations = await GetCompilationsAsync(solution, ct);
+        return new RoslynContext(workspace, solution, compilations, repoRoot);
+    }
+
+    public static async Task<RoslynContext> LoadProjectAsync(string csprojPath, string repoRoot, CancellationToken ct = default)
+    {
+        MsBuildBootstrap.EnsureRegistered();
+        var workspace = MSBuildWorkspace.Create();
+        var project = await workspace.OpenProjectAsync(csprojPath, cancellationToken: ct);
+        var solution = workspace.CurrentSolution;
+        var compilations = await GetCompilationsAsync(solution, ct);
+        return new RoslynContext(workspace, solution, compilations, repoRoot);
+    }
+
+    private static async Task<IReadOnlyDictionary<ProjectId, Compilation>> GetCompilationsAsync(Solution solution, CancellationToken ct)
+    {
+        var dict = new Dictionary<ProjectId, Compilation>();
+        foreach (var project in solution.Projects)
+        {
+            var compilation = await project.GetCompilationAsync(ct);
+            if (compilation != null)
+                dict[project.Id] = compilation;
+        }
+        return dict;
+    }
+}

--- a/tests/CdIndex.Roslyn.Tests/CdIndex.Roslyn.Tests.csproj
+++ b/tests/CdIndex.Roslyn.Tests/CdIndex.Roslyn.Tests.csproj
@@ -1,9 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="xunit.v3.core" Version="3.0.0" />
+    <PackageReference Include="xunit.v3.assert" Version="3.0.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.*" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.9.1" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../../src/CdIndex.Roslyn/CdIndex.Roslyn.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Remove="TestAssets/**/*.cs" />
+    <None Include="TestAssets/**/*" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/tests/CdIndex.Roslyn.Tests/MsBuildBootstrapTests.cs
+++ b/tests/CdIndex.Roslyn.Tests/MsBuildBootstrapTests.cs
@@ -1,0 +1,13 @@
+using Xunit;
+using CdIndex.Roslyn;
+
+public class MsBuildBootstrapTests
+{
+    [Fact]
+    public void EnsureRegistered_IsIdempotent()
+    {
+        MsBuildBootstrap.EnsureRegistered();
+        MsBuildBootstrap.EnsureRegistered();
+        // No exception should be thrown
+    }
+}

--- a/tests/CdIndex.Roslyn.Tests/SolutionLoaderTests.cs
+++ b/tests/CdIndex.Roslyn.Tests/SolutionLoaderTests.cs
@@ -1,0 +1,55 @@
+using System.Threading.Tasks;
+using Xunit;
+using CdIndex.Roslyn;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.IO;
+
+public class SolutionLoaderTests
+{
+    private static string TestRepoRoot => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "TestAssets"));
+    private static string SlnPath => Path.Combine(TestRepoRoot, "MiniHostApp.sln");
+    private static string CsprojPath => Path.Combine(TestRepoRoot, "MiniHostApp", "MiniHostApp.csproj");
+
+    [Fact]
+    public async Task LoadSolutionAsync_LoadsProjectsAndCompilations()
+    {
+        var ctx = await SolutionLoader.LoadSolutionAsync(SlnPath, TestRepoRoot);
+        Assert.NotNull(ctx.Solution);
+        Assert.NotEmpty(ctx.Compilations);
+    }
+
+    [Fact]
+    public async Task GetLocation_ReturnsRepoRelativePathAndLine()
+    {
+        var ctx = await SolutionLoader.LoadSolutionAsync(SlnPath, TestRepoRoot);
+        var programDoc = ctx.Solution.Projects
+            .SelectMany(p => p.Documents)
+            .FirstOrDefault(d => d.Name == "Program.cs");
+        if (programDoc is null)
+            throw new Xunit.Sdk.XunitException("Program.cs not found in loaded solution.");
+        var root = await programDoc.GetSyntaxRootAsync();
+        if (root is null)
+            throw new Xunit.Sdk.XunitException("SyntaxRoot not found for Program.cs.");
+        var mainMethod = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.Text == "Main");
+        var (path, line) = LocationUtil.GetLocation(mainMethod, ctx);
+        Assert.Equal("MiniHostApp/Program.cs", path);
+        Assert.True(line > 0);
+    }
+
+    [Fact]
+    public async Task LoadSolutionAsync_InvalidPath_Throws()
+    {
+        await Assert.ThrowsAsync<System.IO.FileNotFoundException>(async () =>
+        {
+            await SolutionLoader.LoadSolutionAsync("bad_path.sln", TestRepoRoot);
+        });
+    }
+
+    [Fact]
+    public async Task LoadProjectAsync_WorksAnalogously()
+    {
+        var ctx = await SolutionLoader.LoadProjectAsync(CsprojPath, TestRepoRoot);
+        Assert.NotNull(ctx.Solution);
+        Assert.NotEmpty(ctx.Compilations);
+    }
+}

--- a/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp.sln
+++ b/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MiniHostApp", "MiniHostApp/MiniHostApp.csproj", "{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1A1A1A1-A1A1-A1A1-A1A1-A1A1A1A1A1A1}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/MessageHandler.cs
+++ b/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/MessageHandler.cs
@@ -1,0 +1,1 @@
+public sealed class MessageHandler { public void Handle() { } }

--- a/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/MiniHostApp.csproj
+++ b/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/MiniHostApp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/Program.cs
+++ b/tests/CdIndex.Roslyn.Tests/TestAssets/MiniHostApp/Program.cs
@@ -1,0 +1,8 @@
+using System;
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("hi");
+    }
+}


### PR DESCRIPTION
- Implement Roslyn MSBuildWorkspace loader and repo-relative Location helper
- Add SolutionLoader, RoslynContext, MsBuildBootstrap, LocationUtil
- Migrate all Roslyn tests to xUnit v3, .NET 9, Microsoft Testing Platform
- Isolate test assets (MiniHostApp.sln/csproj/Program.cs/MessageHandler.cs) in test project, copy to output, exclude from compilation
- Fix all test paths and asset handling for CI and reproducibility
- All tests pass, CI green
Closes #8 