### PR TITLE
feat: config, commands, flow extractors (p1-1, p1-2, p1-3)

### DIFF
--- a/.changelog-p1-1.md
+++ b/.changelog-p1-1.md
@@ -1,0 +1,3 @@
+# p1-1 bootstrap
+
+Draft branch created for issue #16 (Config extractor). Implementation commits will follow.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# cd-index
+
+.NET 9 CLI tool that scans a C# solution/project and emits a deterministic JSON index (tree, DI, entrypoints, configs, commands, message flow, and more forthcoming) according to `schema/project_index.schema.json`.
+
+## Features (P1 additions)
+- Config extractor (`--scan-configs` + `--env-prefix`): collects environment variable keys (by prefix) and referenced app config interface properties.
+- Commands extractor (`--scan-commands`): collects chat/command registrations (`/start`, etc.) from router registrations and simple comparison patterns.
+- Message flow extractor (`--scan-flow --flow-handler <Type> [--flow-method <Method>]`): linearizes guards, delegate calls, returns inside specified handler method.
+
+## Usage
+
+Basic scan:
+```
+cd-index scan --sln path/to/solution.sln --out index.json
+```
+
+Optional sections:
+```
+# Configs
+cd-index scan --sln path/to/ConfApp.sln --scan-configs --env-prefix DOORMAN_ --env-prefix MYAPP_ --out conf.json
+
+# Commands
+cd-index scan --sln path/to/CmdApp.sln --scan-commands --out cmd.json
+
+# Message Flow
+cd-index scan --sln path/to/FlowApp.sln --scan-flow --flow-handler MessageHandler --flow-method HandleAsync --out flow.json
+```
+
+Self-check (deterministic minimal output):
+```
+cd-index --selfcheck --scan-tree-only
+```
+
+## Determinism
+All emitted JSON collections are sorted (ordinal). Paths are repo-relative with forward slashes. Re-running the same command yields byte-identical output except `GeneratedAt` timestamp.
+
+## Schema
+See `schema/project_index.schema.json`. New sections (v1.1): `Configs`, `Commands`, `MessageFlow`.
+
+## Tests
+Run all tests:
+```
+dotnet test
+```
+Key suites:
+- `ConfigExtractorTests`
+- `CommandsExtractorTests`
+- `FlowExtractorTests`
+- Determinism: `SelfCheckDeterminismTests`
+
+## Roadmap
+Further extractors (callgraphs, test detection) to follow; focus remains on deterministic, minimal, dependency-light implementation.

--- a/schema/project_index.schema.json
+++ b/schema/project_index.schema.json
@@ -212,7 +212,24 @@
     },
     "Configs": {
       "type": "array",
-      "description": "Configuration analysis (future extension)"
+      "description": "Configuration analysis",
+      "items": {
+        "type": "object",
+        "required": ["EnvKeys", "AppProps"],
+        "properties": {
+          "EnvKeys": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Sorted unique environment variable keys discovered"
+          },
+          "AppProps": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Sorted unique application config properties in form Type.Property"
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "Commands": {
       "type": "array",

--- a/schema/project_index.schema.json
+++ b/schema/project_index.schema.json
@@ -233,7 +233,28 @@
     },
     "Commands": {
       "type": "array",
-      "description": "Command analysis (future extension)"
+      "description": "Command analysis",
+      "items": {
+        "type": "object",
+        "required": ["Items"],
+        "properties": {
+          "Items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["Command", "File", "Line"],
+              "properties": {
+                "Command": { "type": "string", "description": "Chat command text incl. leading slash" },
+                "Handler": { "type": ["string", "null"], "description": "Resolved handler type/name if any" },
+                "File": { "type": "string", "description": "Repo-relative file path" },
+                "Line": { "type": "integer", "minimum": 1, "description": "Line number (1-based)" }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "Tests": {
       "type": "array",

--- a/schema/project_index.schema.json
+++ b/schema/project_index.schema.json
@@ -204,7 +204,29 @@
     },
     "MessageFlow": {
       "type": "array",
-      "description": "Message flow analysis (future extension)"
+      "description": "Message flow analysis",
+      "items": {
+        "type": "object",
+        "required": ["Nodes"],
+        "properties": {
+          "Nodes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["Order", "Kind", "Detail", "File", "Line"],
+              "properties": {
+                "Order": { "type": "integer", "minimum": 0 },
+                "Kind": { "type": "string", "enum": ["guard", "delegate", "return", "other" ] },
+                "Detail": { "type": "string" },
+                "File": { "type": "string" },
+                "Line": { "type": "integer", "minimum": 1 }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
     },
     "Callgraphs": {
       "type": "array",

--- a/src/CdIndex.Cli/Program.cs
+++ b/src/CdIndex.Cli/Program.cs
@@ -21,6 +21,8 @@ Options:
   --scan-tree / --no-scan-tree            Enable/disable tree section (default on)
   --scan-di / --no-scan-di                Enable/disable DI extraction (default on)
   --scan-entrypoints / --no-scan-entrypoints  Enable/disable entrypoints (default on)
+    --scan-configs / --no-scan-configs  Enable/disable configs extraction (default off)
+    --env-prefix <P>        Add environment variable prefix filter (repeatable, default DOORMAN_)
   --verbose               Verbose diagnostics to stderr
   -h, --help              Show this help
 ";
@@ -69,7 +71,8 @@ Options:
             var exts = new List<string>();
             var ignores = new List<string>();
             var locMode = "physical";
-            bool scanTree = true, scanDi = true, scanEntrypoints = true, verbose = false;
+            bool scanTree = true, scanDi = true, scanEntrypoints = true, scanConfigs = false, verbose = false;
+            var envPrefixes = new List<string>();
             for (int i = 1; i < args.Length; i++)
             {
                 var a = args[i];
@@ -88,6 +91,9 @@ Options:
                     case "--no-scan-di": scanDi = false; break;
                     case "--no-scan-entrypoints": scanEntrypoints = false; break;
                     case "--verbose": verbose = true; break;
+                    case "--scan-configs": scanConfigs = true; break;
+                    case "--no-scan-configs": scanConfigs = false; break;
+                    case "--env-prefix": if (i + 1 < args.Length) envPrefixes.Add(args[++i]); else return 5; break;
                     case "--help":
                     case "-h":
                     case "help":
@@ -108,6 +114,8 @@ Options:
                 scanTree,
                 scanDi,
                 scanEntrypoints,
+                scanConfigs,
+                envPrefixes,
                 verbose);
             return code;
         }

--- a/src/CdIndex.Cli/Program.cs
+++ b/src/CdIndex.Cli/Program.cs
@@ -9,26 +9,26 @@ class Program
 {
     static int Main(string[] args)
     {
-    const string ScanUsage = @"Usage: cd-index scan (--sln <file.sln> | --csproj <project.csproj>) [options]
+        const string ScanUsage = @"Usage: cd-index scan (--sln <file.sln> | --csproj <project.csproj>) [options]
 
 Options:
-  --sln <path>              Path to solution file (mutually exclusive with --csproj)
-  --csproj <path>           Path to project file (mutually exclusive with --sln)
-  --out <file>              Write JSON to file (default stdout)
-  --ext <extension>         Additional file extension to include (repeatable)
-  --ignore <glob|prefix>    Path prefix or suffix to ignore (repeatable)
-  --loc-mode <physical|logical>  LOC counting mode (default physical)
-  --scan-tree / --no-scan-tree            Enable/disable tree section (default on)
-  --scan-di / --no-scan-di                Enable/disable DI extraction (default on)
-  --scan-entrypoints / --no-scan-entrypoints  Enable/disable entrypoints (default on)
-    --scan-configs / --no-scan-configs  Enable/disable configs extraction (default off)
-    --env-prefix <P>        Add environment variable prefix filter (repeatable, default DOORMAN_)
-        --scan-commands / --no-scan-commands  Enable/disable commands extraction (default off)
-        --scan-flow / --no-scan-flow        Enable/disable message flow extraction (default off)
-        --flow-handler <TypeName>           Handler class name for flow (required if --scan-flow)
-        --flow-method <MethodName>          Handler method name for flow (default HandleAsync)
-    --verbose               Verbose diagnostics to stderr
-  -h, --help              Show this help
+    --sln <path>                     Path to solution file (mutually exclusive with --csproj)
+    --csproj <path>                  Path to project file (mutually exclusive with --sln)
+    --out <file>                     Write JSON to file (default stdout)
+    --ext <extension>                Additional file extension to include (repeatable)
+    --ignore <glob|prefix>           Path prefix or suffix to ignore (repeatable)
+    --loc-mode <physical|logical>    LOC counting mode (default physical)
+    --scan-tree / --no-scan-tree     Enable/disable tree section (default on)
+    --scan-di / --no-scan-di         Enable/disable DI extraction (default on)
+    --scan-entrypoints / --no-scan-entrypoints  Enable/disable entrypoints (default on)
+    --scan-configs / --no-scan-configs          Enable/disable configs extraction (default off)
+    --env-prefix <P>                 Add environment variable prefix filter (repeatable, default DOORMAN_)
+    --scan-commands / --no-scan-commands        Enable/disable commands extraction (default off)
+    --scan-flow / --no-scan-flow     Enable/disable message flow extraction (default off)
+    --flow-handler <TypeName>        Handler class name for flow (required if --scan-flow)
+    --flow-method <MethodName>       Handler method name for flow (default HandleAsync)
+    --verbose                        Verbose diagnostics to stderr
+    -h, --help                       Show this help
 ";
 
     bool IsHelp(string a) => a == "--help" || a == "-h" || a == "help";
@@ -135,12 +135,12 @@ Options:
             return code;
         }
 
-        var parseResult = rootCommand.Parse(args);
-        if (parseResult.GetValue(versionOption))
+        if (args.Contains("--version", StringComparer.Ordinal))
         {
             Console.WriteLine("cd-index v0.0.1-dev");
             return 0;
         }
+        var parseResult = rootCommand.Parse(args);
         if (parseResult.GetValue(selfCheckOption))
         {
             var scanTreeOnly = parseResult.GetValue(scanTreeOnlyOption);

--- a/src/CdIndex.Cli/Program.cs
+++ b/src/CdIndex.Cli/Program.cs
@@ -23,6 +23,7 @@ Options:
   --scan-entrypoints / --no-scan-entrypoints  Enable/disable entrypoints (default on)
     --scan-configs / --no-scan-configs  Enable/disable configs extraction (default off)
     --env-prefix <P>        Add environment variable prefix filter (repeatable, default DOORMAN_)
+        --scan-commands / --no-scan-commands  Enable/disable commands extraction (default off)
   --verbose               Verbose diagnostics to stderr
   -h, --help              Show this help
 ";
@@ -71,7 +72,7 @@ Options:
             var exts = new List<string>();
             var ignores = new List<string>();
             var locMode = "physical";
-            bool scanTree = true, scanDi = true, scanEntrypoints = true, scanConfigs = false, verbose = false;
+            bool scanTree = true, scanDi = true, scanEntrypoints = true, scanConfigs = false, scanCommands = false, verbose = false;
             var envPrefixes = new List<string>();
             for (int i = 1; i < args.Length; i++)
             {
@@ -94,6 +95,8 @@ Options:
                     case "--scan-configs": scanConfigs = true; break;
                     case "--no-scan-configs": scanConfigs = false; break;
                     case "--env-prefix": if (i + 1 < args.Length) envPrefixes.Add(args[++i]); else return 5; break;
+                    case "--scan-commands": scanCommands = true; break;
+                    case "--no-scan-commands": scanCommands = false; break;
                     case "--help":
                     case "-h":
                     case "help":
@@ -116,6 +119,7 @@ Options:
                 scanEntrypoints,
                 scanConfigs,
                 envPrefixes,
+                scanCommands,
                 verbose);
             return code;
         }

--- a/src/CdIndex.Cli/Program.cs
+++ b/src/CdIndex.Cli/Program.cs
@@ -24,7 +24,10 @@ Options:
     --scan-configs / --no-scan-configs  Enable/disable configs extraction (default off)
     --env-prefix <P>        Add environment variable prefix filter (repeatable, default DOORMAN_)
         --scan-commands / --no-scan-commands  Enable/disable commands extraction (default off)
-  --verbose               Verbose diagnostics to stderr
+        --scan-flow / --no-scan-flow        Enable/disable message flow extraction (default off)
+        --flow-handler <TypeName>           Handler class name for flow (required if --scan-flow)
+        --flow-method <MethodName>          Handler method name for flow (default HandleAsync)
+    --verbose               Verbose diagnostics to stderr
   -h, --help              Show this help
 ";
 
@@ -72,7 +75,8 @@ Options:
             var exts = new List<string>();
             var ignores = new List<string>();
             var locMode = "physical";
-            bool scanTree = true, scanDi = true, scanEntrypoints = true, scanConfigs = false, scanCommands = false, verbose = false;
+            bool scanTree = true, scanDi = true, scanEntrypoints = true, scanConfigs = false, scanCommands = false, scanFlow = false, verbose = false;
+            string? flowHandler = null; string flowMethod = "HandleAsync";
             var envPrefixes = new List<string>();
             for (int i = 1; i < args.Length; i++)
             {
@@ -97,6 +101,10 @@ Options:
                     case "--env-prefix": if (i + 1 < args.Length) envPrefixes.Add(args[++i]); else return 5; break;
                     case "--scan-commands": scanCommands = true; break;
                     case "--no-scan-commands": scanCommands = false; break;
+                    case "--scan-flow": scanFlow = true; break;
+                    case "--no-scan-flow": scanFlow = false; break;
+                    case "--flow-handler": if (i + 1 < args.Length) flowHandler = args[++i]; else return 5; break;
+                    case "--flow-method": if (i + 1 < args.Length) flowMethod = args[++i]; else return 5; break;
                     case "--help":
                     case "-h":
                     case "help":
@@ -120,6 +128,9 @@ Options:
                 scanConfigs,
                 envPrefixes,
                 scanCommands,
+                scanFlow,
+                flowHandler,
+                flowMethod,
                 verbose);
             return code;
         }

--- a/src/CdIndex.Cli/ScanCommand.cs
+++ b/src/CdIndex.Cli/ScanCommand.cs
@@ -11,7 +11,7 @@ namespace CdIndex.Cli;
 
 internal static class ScanCommand
 {
-    public static int Run(FileInfo? sln, FileInfo? csproj, FileInfo? outFile, string[] exts, string[] ignores, string locMode, bool scanTree, bool scanDi, bool scanEntrypoints, bool scanConfigs, List<string> envPrefixes, bool verbose)
+    public static int Run(FileInfo? sln, FileInfo? csproj, FileInfo? outFile, string[] exts, string[] ignores, string locMode, bool scanTree, bool scanDi, bool scanEntrypoints, bool scanConfigs, List<string> envPrefixes, bool scanCommands, bool verbose)
     {
         var hasSln = sln != null;
         var hasProj = csproj != null;
@@ -115,6 +115,21 @@ internal static class ScanCommand
             }
         }
 
+        var commandSections = new List<CommandSection>();
+        if (scanCommands)
+        {
+            try
+            {
+                var cmdExtractor = new CommandsExtractor();
+                cmdExtractor.Extract(roslyn);
+                commandSections.Add(new CommandSection(cmdExtractor.Items.ToList()));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine("WARN: Commands extraction failed: " + ex.Message);
+            }
+        }
+
         var index = new ProjectIndex(
             meta,
             projectSections,
@@ -124,7 +139,7 @@ internal static class ScanCommand
             Array.Empty<MessageFlowSection>(),
             Array.Empty<CallgraphSection>(),
             configSections,
-            Array.Empty<CommandSection>(),
+            commandSections,
             Array.Empty<TestSection>()
         );
 

--- a/src/CdIndex.Core/ProjectIndex.cs
+++ b/src/CdIndex.Core/ProjectIndex.cs
@@ -49,7 +49,10 @@ public sealed record ProgramMain(string File, int Line, string? TypeName);
 
 public sealed record MessageFlowSection;
 public sealed record CallgraphSection;
-public sealed record ConfigSection;
+public sealed record ConfigSection(
+    IReadOnlyList<string> EnvKeys,
+    IReadOnlyList<string> AppProps
+);
 public sealed record CommandSection;
 public sealed record TestSection;
 

--- a/src/CdIndex.Core/ProjectIndex.cs
+++ b/src/CdIndex.Core/ProjectIndex.cs
@@ -47,7 +47,9 @@ public sealed record EntrypointsSection(
 public sealed record ProjectRef(string Name, string File);
 public sealed record ProgramMain(string File, int Line, string? TypeName);
 
-public sealed record MessageFlowSection;
+public sealed record MessageFlowSection(
+    IReadOnlyList<FlowNode> Nodes
+);
 public sealed record CallgraphSection;
 public sealed record ConfigSection(
     IReadOnlyList<string> EnvKeys,
@@ -63,6 +65,14 @@ public sealed record CommandItem(
     int Line
 );
 public sealed record TestSection;
+
+public sealed record FlowNode(
+    int Order,
+    string Kind,
+    string Detail,
+    string File,
+    int Line
+);
 
 // Supporting types for P0 sections
 

--- a/src/CdIndex.Core/ProjectIndex.cs
+++ b/src/CdIndex.Core/ProjectIndex.cs
@@ -53,7 +53,15 @@ public sealed record ConfigSection(
     IReadOnlyList<string> EnvKeys,
     IReadOnlyList<string> AppProps
 );
-public sealed record CommandSection;
+public sealed record CommandSection(
+    IReadOnlyList<CommandItem> Items
+);
+public sealed record CommandItem(
+    string Command,
+    string? Handler,
+    string File,
+    int Line
+);
 public sealed record TestSection;
 
 // Supporting types for P0 sections

--- a/src/CdIndex.Emit/JsonEmitter.cs
+++ b/src/CdIndex.Emit/JsonEmitter.cs
@@ -88,6 +88,14 @@ public static class JsonEmitter
                 if (n != 0) return n;
                 return string.Compare(a.Project.File, b.Project.File, StringComparison.Ordinal);
             }));
+
+        // Order Config sections (each contains sorted lists already, but ensure deterministic ordering if multiple later)
+        var orderedConfigs = Orderer.Sort(
+            index.Configs.Select(c => new ConfigSection(
+                c.EnvKeys.OrderBy(x => x, StringComparer.Ordinal).ToList(),
+                c.AppProps.OrderBy(x => x, StringComparer.Ordinal).ToList()
+            )),
+            Comparer<ConfigSection>.Create((_, _) => 0));
         // Force Meta.SchemaVersion to 1.1 (immutability -> create new Meta)
         var meta = new Meta(index.Meta.Version, "1.1", index.Meta.GeneratedAt, index.Meta.RepositoryUrl);
 
@@ -99,7 +107,7 @@ public static class JsonEmitter
             orderedEntrypoints,
             index.MessageFlow,
             index.Callgraphs,
-            index.Configs,
+            orderedConfigs,
             index.Commands,
             index.Tests
         );

--- a/src/CdIndex.Extractors/CommandsExtractor.cs
+++ b/src/CdIndex.Extractors/CommandsExtractor.cs
@@ -1,0 +1,131 @@
+using CdIndex.Core;
+using CdIndex.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CdIndex.Extractors;
+
+public sealed class CommandsExtractor : IExtractor
+{
+    private readonly List<CommandItem> _items = new();
+    private readonly HashSet<(string,string?,string,int)> _dedup = new();
+
+    public IReadOnlyList<CommandItem> Items => _items;
+
+    public void Extract(RoslynContext context)
+    {
+        _items.Clear();
+        _dedup.Clear();
+        foreach (var project in context.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath?.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) != true) continue;
+                var root = doc.GetSyntaxRootAsync().Result as CSharpSyntaxNode;
+                if (root == null) continue;
+                var semantic = doc.GetSemanticModelAsync().Result;
+                if (semantic == null) continue;
+
+                CollectRouterRegistrations(root, semantic, context);
+                CollectComparisons(root, semantic, context);
+            }
+        }
+        _items.Sort((a,b) =>
+        {
+            var c = string.Compare(a.Command, b.Command, StringComparison.Ordinal);
+            if (c != 0) return c;
+            return string.Compare(a.Handler, b.Handler, StringComparison.Ordinal);
+        });
+    }
+
+    private void CollectRouterRegistrations(CSharpSyntaxNode root, SemanticModel semantic, RoslynContext ctx)
+    {
+        var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>();
+        foreach (var inv in invocations)
+        {
+            if (inv.Expression is not MemberAccessExpressionSyntax ma) continue;
+            var name = ma.Name switch
+            {
+                GenericNameSyntax g => g.Identifier.ValueText,
+                IdentifierNameSyntax id => id.Identifier.ValueText,
+                _ => null
+            };
+            if (name == null) continue;
+            if (!IsRouterRegistrationName(name)) continue;
+            if (inv.ArgumentList.Arguments.Count == 0) continue;
+            var firstArg = inv.ArgumentList.Arguments[0].Expression;
+            var literal = firstArg as LiteralExpressionSyntax;
+            if (literal?.IsKind(SyntaxKind.StringLiteralExpression) != true) continue;
+            var cmdText = literal.Token.ValueText;
+            if (!IsCommandLiteral(cmdText)) continue;
+            string? handler = null;
+            // Generic handler type parameter
+            if (ma.Name is GenericNameSyntax gname && gname.TypeArgumentList.Arguments.Count == 1)
+            {
+                handler = gname.TypeArgumentList.Arguments[0].ToString();
+            }
+            else if (inv.ArgumentList.Arguments.Count > 1)
+            {
+                // second arg maybe new Handler()
+                var second = inv.ArgumentList.Arguments[1].Expression;
+                if (second is ObjectCreationExpressionSyntax oce)
+                {
+                    handler = oce.Type.ToString();
+                }
+                else if (second is IdentifierNameSyntax idn)
+                {
+                    handler = idn.Identifier.ValueText;
+                }
+            }
+            else
+            {
+                // maybe first arg is string and second implicit new Handler() with collection initializer? skip
+            }
+
+            var (file,line) = LocationUtil.GetLocation(inv, ctx);
+            Add(cmdText, handler, file, line);
+        }
+    }
+
+    private void CollectComparisons(CSharpSyntaxNode root, SemanticModel semantic, RoslynContext ctx)
+    {
+        foreach (var bin in root.DescendantNodes().OfType<BinaryExpressionSyntax>())
+        {
+            if (!bin.IsKind(SyntaxKind.EqualsExpression)) continue;
+            var leftLit = bin.Left as LiteralExpressionSyntax;
+            var rightLit = bin.Right as LiteralExpressionSyntax;
+            var lit = leftLit ?? rightLit;
+            if (lit?.IsKind(SyntaxKind.StringLiteralExpression) != true) continue;
+            var text = lit.Token.ValueText;
+            if (!IsCommandLiteral(text)) continue;
+            var (file,line) = LocationUtil.GetLocation(bin, ctx);
+            Add(text, null, file, line);
+        }
+
+        // method invocations like text.Equals("/help") or text.StartsWith("/ban")
+        foreach (var inv in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (inv.Expression is not MemberAccessExpressionSyntax ma) continue;
+            var id = ma.Name.Identifier.ValueText;
+            if (id is not ("Equals" or "StartsWith")) continue;
+            if (inv.ArgumentList.Arguments.Count == 0) continue;
+            var arg = inv.ArgumentList.Arguments[0].Expression as LiteralExpressionSyntax;
+            if (arg?.IsKind(SyntaxKind.StringLiteralExpression) != true) continue;
+            var text = arg.Token.ValueText;
+            if (!IsCommandLiteral(text)) continue;
+            var (file,line) = LocationUtil.GetLocation(inv, ctx);
+            Add(text, null, file, line);
+        }
+    }
+
+    private static bool IsCommandLiteral(string s) => s.Length > 1 && s[0] == '/';
+    private static bool IsRouterRegistrationName(string name) => name is "Map" or "Register" or "Add" or "On" or "Handle";
+
+    private void Add(string command, string? handler, string file, int line)
+    {
+        var key = (command, handler, file, line);
+        if (_dedup.Add(key))
+            _items.Add(new CommandItem(command, handler, file, line));
+    }
+}

--- a/src/CdIndex.Extractors/ConfigExtractor.cs
+++ b/src/CdIndex.Extractors/ConfigExtractor.cs
@@ -1,0 +1,103 @@
+using CdIndex.Core;
+using CdIndex.Roslyn;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis;
+
+namespace CdIndex.Extractors;
+
+public sealed class ConfigExtractor : IExtractor
+{
+    private readonly HashSet<string> _envPrefixes;
+    private readonly HashSet<string> _envKeys = new(StringComparer.Ordinal);
+    private readonly HashSet<string> _appProps = new(StringComparer.Ordinal);
+
+    public ConfigExtractor(IEnumerable<string>? envPrefixes = null)
+    {
+        _envPrefixes = new HashSet<string>((envPrefixes ?? new[] { "DOORMAN_" }), StringComparer.Ordinal);
+    }
+
+    public IReadOnlyCollection<string> EnvKeys => _envKeys;
+    public IReadOnlyCollection<string> AppProps => _appProps;
+
+    public void Extract(RoslynContext context)
+    {
+        _envKeys.Clear();
+        _appProps.Clear();
+
+        foreach (var project in context.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath?.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) != true) continue;
+                var root = doc.GetSyntaxRootAsync().Result as CSharpSyntaxNode;
+                if (root == null) continue;
+                var semantic = doc.GetSemanticModelAsync().Result;
+                if (semantic == null) continue;
+
+                CollectEnvLiterals(root);
+                CollectAppProps(root, semantic);
+            }
+        }
+    }
+
+    private void CollectEnvLiterals(CSharpSyntaxNode root)
+    {
+        foreach (var lit in root.DescendantNodes().OfType<LiteralExpressionSyntax>())
+        {
+            if (lit.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.StringLiteralExpression))
+            {
+                var text = lit.Token.ValueText;
+                foreach (var prefix in _envPrefixes)
+                {
+                    if (text.StartsWith(prefix, StringComparison.Ordinal) && text.Length > prefix.Length)
+                    {
+                        _envKeys.Add(text);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private void CollectAppProps(CSharpSyntaxNode root, SemanticModel semantic)
+    {
+        foreach (var member in root.DescendantNodes().OfType<MemberAccessExpressionSyntax>())
+        {
+            var symbol = semantic.GetSymbolInfo(member.Expression).Symbol;
+            if (symbol == null) continue;
+            var type = symbol switch
+            {
+                ILocalSymbol ls => ls.Type,
+                IParameterSymbol ps => ps.Type,
+                IPropertySymbol prs => prs.Type,
+                IFieldSymbol fs => fs.Type,
+                IMethodSymbol ms => ms.ReturnType,
+                INamedTypeSymbol nts => nts,
+                _ => null
+            } as INamedTypeSymbol;
+            if (type == null) continue;
+            if (!IsAppConfigLike(type)) continue;
+            var propName = member.Name.Identifier.ValueText;
+            if (string.IsNullOrEmpty(propName)) continue;
+            _appProps.Add(type.Name + "." + propName);
+        }
+    }
+
+    private static bool IsAppConfigLike(INamedTypeSymbol type)
+    {
+        if (type.Name == "IAppConfig" || type.Name.EndsWith("Config", StringComparison.Ordinal)) return true;
+        foreach (var i in type.AllInterfaces)
+        {
+            if (i.Name == "IAppConfig" || i.Name.EndsWith("Config", StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
+    public ConfigSection CreateSection()
+    {
+        var env = _envKeys.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        var props = _appProps.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        return new ConfigSection(env, props);
+    }
+}

--- a/src/CdIndex.Extractors/FlowExtractor.cs
+++ b/src/CdIndex.Extractors/FlowExtractor.cs
@@ -1,0 +1,139 @@
+using CdIndex.Core;
+using CdIndex.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace CdIndex.Extractors;
+
+public sealed class FlowExtractor : IExtractor
+{
+    private readonly string _handlerType;
+    private readonly string _methodName;
+    private readonly List<FlowNode> _nodes = new();
+
+    public FlowExtractor(string handlerType, string methodName = "HandleAsync")
+    {
+        _handlerType = handlerType;
+        _methodName = methodName;
+    }
+
+    public IReadOnlyList<FlowNode> Nodes => _nodes;
+
+    public void Extract(RoslynContext context)
+    {
+        _nodes.Clear();
+        foreach (var project in context.Solution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath?.EndsWith(".cs", StringComparison.OrdinalIgnoreCase) != true) continue;
+                var root = doc.GetSyntaxRootAsync().Result as CSharpSyntaxNode;
+                if (root == null) continue;
+                var semantic = doc.GetSemanticModelAsync().Result;
+                if (semantic == null) continue;
+
+                foreach (var decl in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+                {
+                    var name = decl.Identifier.ValueText;
+                    if (name != _handlerType) continue; // simple name match
+                    var method = decl.Members.OfType<MethodDeclarationSyntax>()
+                        .FirstOrDefault(m => m.Identifier.ValueText == _methodName);
+                    if (method == null) continue;
+                    ProcessMethod(method, context);
+                }
+            }
+        }
+    for (int i = 0; i < _nodes.Count; i++)
+        {
+            var n = _nodes[i];
+            _nodes[i] = n with { Order = i };
+        }
+    }
+
+    private void ProcessMethod(MethodDeclarationSyntax method, RoslynContext ctx)
+    {
+        if (method.Body == null) return;
+        foreach (var stmt in method.Body.Statements)
+        {
+            switch (stmt)
+            {
+                case IfStatementSyntax ifs:
+                    HandleIf(ifs, ctx);
+                    break;
+                case ExpressionStatementSyntax es:
+                    HandleExpressionStatement(es, ctx);
+                    break;
+                case ReturnStatementSyntax rs:
+                    AddNode("return", "return", rs, ctx);
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+
+    private void HandleIf(IfStatementSyntax ifs, RoslynContext ctx)
+    {
+        // Pattern collapse: if (Cond()) { Facade.Handle(); return; } -> delegate only (skip guard)
+        if (ifs.Statement is BlockSyntax blk && blk.Statements.Count == 2 &&
+            blk.Statements[0] is ExpressionStatementSyntax firstExpr &&
+            blk.Statements[1] is ReturnStatementSyntax)
+        {
+            if (TryDelegateInvocation(firstExpr.Expression, ctx, add: false))
+            {
+                // Add only delegate node (skip guard) per heuristic
+                TryDelegateInvocation(firstExpr.Expression, ctx, add: true);
+                return;
+            }
+        }
+
+        // Standard guard (includes simple 'return;' statement or other forms)
+        AddNode("guard", ifs.Condition.ToString(), ifs, ctx);
+
+        if (ifs.Statement is BlockSyntax block)
+        {
+            foreach (var inner in block.Statements)
+            {
+                if (inner is ExpressionStatementSyntax es)
+                {
+                    TryDelegateInvocation(es.Expression, ctx);
+                }
+                else if (inner is ReturnStatementSyntax rs)
+                {
+                    AddNode("return", "return", rs, ctx);
+                }
+            }
+        }
+        else if (ifs.Statement is ExpressionStatementSyntax es2)
+        {
+            TryDelegateInvocation(es2.Expression, ctx);
+        }
+    }
+
+    private void HandleExpressionStatement(ExpressionStatementSyntax es, RoslynContext ctx)
+    {
+        TryDelegateInvocation(es.Expression, ctx);
+    }
+
+    private bool TryDelegateInvocation(ExpressionSyntax expr, RoslynContext ctx, bool add = true)
+    {
+        if (expr is InvocationExpressionSyntax inv && inv.Expression is MemberAccessExpressionSyntax ma)
+        {
+            var exprText = ma.Expression.ToString();
+            if (exprText.EndsWith("Facade", StringComparison.Ordinal) || exprText.EndsWith("Service", StringComparison.Ordinal) || exprText == "Router")
+            {
+                if (add)
+                    AddNode("delegate", exprText + "." + ma.Name.Identifier.ValueText, inv, ctx);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void AddNode(string kind, string detail, SyntaxNode node, RoslynContext ctx)
+    {
+    var (file, line) = LocationUtil.GetLocation(node, ctx);
+        _nodes.Add(new FlowNode(-1, kind, detail, file, line));
+    }
+}

--- a/tests/CdIndex.Cli.Tests/ScanNewSectionsTests.cs
+++ b/tests/CdIndex.Cli.Tests/ScanNewSectionsTests.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Xunit;
+
+public class ScanNewSectionsTests
+{
+    private static string RepoRoot()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (!string.IsNullOrEmpty(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "cd-index.sln"))) return dir;
+            var parent = Directory.GetParent(dir)?.FullName;
+            if (parent == null || parent == dir) break;
+            dir = parent;
+        }
+        throw new InvalidOperationException("Repo root not found");
+    }
+
+    private static string CliDll() => Path.Combine(RepoRoot(), "src", "CdIndex.Cli", "bin", "Debug", "net9.0", "CdIndex.Cli.dll");
+
+    private static JsonNode Run(string args)
+    {
+        var exe = CliDll();
+        if (!File.Exists(exe)) throw new FileNotFoundException(exe);
+        var psi = new ProcessStartInfo("dotnet", exe + " " + args)
+        {
+            WorkingDirectory = RepoRoot(),
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        using var p = Process.Start(psi)!;
+        var output = p.StandardOutput.ReadToEnd();
+        p.WaitForExit();
+        Assert.Equal(0, p.ExitCode);
+        Assert.False(string.IsNullOrWhiteSpace(output));
+        return JsonNode.Parse(output)!;
+    }
+
+    [Fact]
+    public void Scan_ConfigsSection_PopulatedAndSorted()
+    {
+        var root = RepoRoot();
+        var sln = Path.Combine(root, "tests", "CdIndex.Extractors.Tests", "TestAssets", "ConfApp", "ConfApp.sln");
+        var json = Run($"scan --sln {sln} --scan-configs");
+        var configs = json["Configs"]!.AsArray();
+        Assert.NotEmpty(configs);
+        var first = configs[0]!;
+        var envKeys = first["EnvKeys"]!.AsArray().Select(n => n!.GetValue<string>()).ToList();
+        var appProps = first["AppProps"]!.AsArray().Select(n => n!.GetValue<string>()).ToList();
+        Assert.Contains("DOORMAN_BOT_API", envKeys);
+        Assert.True(envKeys.SequenceEqual(envKeys.OrderBy(x => x, StringComparer.Ordinal)));
+        Assert.Contains("IAppConfig.AdminChatId", appProps);
+    }
+
+    [Fact]
+    public void Scan_CommandsSection_Populated()
+    {
+        var root = RepoRoot();
+        var sln = Path.Combine(root, "tests", "CdIndex.Extractors.Tests", "TestAssets", "CmdApp", "CmdApp.sln");
+        var json = Run($"scan --sln {sln} --scan-commands");
+        var commands = json["Commands"]!.AsArray();
+        Assert.NotEmpty(commands);
+        var firstSection = commands[0]!;
+        var items = firstSection["Items"]!.AsArray();
+        Assert.Contains(items, i => i!["Command"]!.GetValue<string>() == "/start");
+        Assert.Contains(items, i => i!["Command"]!.GetValue<string>() == "/stats");
+    }
+
+    [Fact]
+    public void Scan_MessageFlowSection_Sequence()
+    {
+        var root = RepoRoot();
+        var sln = Path.Combine(root, "tests", "CdIndex.Extractors.Tests", "TestAssets", "FlowApp", "FlowApp.sln");
+        var json = Run($"scan --sln {sln} --scan-flow --flow-handler MessageHandler");
+        var flow = json["MessageFlow"]!.AsArray();
+        Assert.NotEmpty(flow);
+        var section = flow[0]!;
+        var nodes = section["Nodes"]!.AsArray();
+        Assert.True(nodes.Count >= 6);
+        string[] expectedKinds = { "guard", "guard", "delegate", "guard", "delegate", "delegate" };
+        for (int i = 0; i < expectedKinds.Length; i++)
+        {
+            Assert.Equal(expectedKinds[i], nodes[i]!["Kind"]!.GetValue<string>());
+            Assert.Equal(i, nodes[i]!["Order"]!.GetValue<int>());
+        }
+    }
+}

--- a/tests/CdIndex.Extractors.Tests/DiExtractorTests.cs
+++ b/tests/CdIndex.Extractors.Tests/DiExtractorTests.cs
@@ -164,3 +164,36 @@ public sealed class DiExtractorTests
         Assert.True(docCount > 0, "No documents loaded from DiApp.sln. Check build and asset paths.");
     }
 }
+
+public sealed class ConfigExtractorTests
+{
+    private static string TestRepoRoot => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "TestAssets"));
+    private static string SlnPath => Path.Combine(TestRepoRoot, "ConfApp", "ConfApp.sln");
+
+    [Fact]
+    public async Task ConfigExtractor_FindsEnvKeysAndAppProps()
+    {
+        var ctx = await SolutionLoader.LoadSolutionAsync(SlnPath, TestRepoRoot);
+        var extractor = new ConfigExtractor();
+        extractor.Extract(ctx);
+        var section = extractor.CreateSection();
+        Assert.Contains("DOORMAN_BOT_API", section.EnvKeys);
+        Assert.Contains("DOORMAN_LOG_ADMIN_CHAT", section.EnvKeys);
+        Assert.Contains("IAppConfig.AdminChatId", section.AppProps);
+        Assert.Contains("IAppConfig.AiEnabled", section.AppProps);
+        Assert.Contains("FeatureConfig.FeatureX", section.AppProps);
+        // Sorted uniqueness
+        var sortedEnv = section.EnvKeys.OrderBy(x => x, StringComparer.Ordinal).ToList();
+        Assert.Equal(sortedEnv, section.EnvKeys.ToList());
+    }
+
+    [Fact]
+    public async Task ConfigExtractor_CustomPrefix()
+    {
+        var ctx = await SolutionLoader.LoadSolutionAsync(SlnPath, TestRepoRoot);
+        var extractor = new ConfigExtractor(new[]{"DOORMAN_", "MYAPP_"});
+        extractor.Extract(ctx);
+        var section = extractor.CreateSection();
+        Assert.Contains("DOORMAN_BOT_API", section.EnvKeys);
+    }
+}

--- a/tests/CdIndex.Extractors.Tests/DiExtractorTests.cs
+++ b/tests/CdIndex.Extractors.Tests/DiExtractorTests.cs
@@ -197,3 +197,26 @@ public sealed class ConfigExtractorTests
         Assert.Contains("DOORMAN_BOT_API", section.EnvKeys);
     }
 }
+
+public sealed class CommandsExtractorTests
+{
+    private static string TestRepoRoot => Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "TestAssets"));
+    private static string SlnPath => Path.Combine(TestRepoRoot, "CmdApp", "CmdApp.sln");
+
+    [Fact]
+    public async Task CommandsExtractor_FindsCoreCommands()
+    {
+        var ctx = await SolutionLoader.LoadSolutionAsync(SlnPath, TestRepoRoot);
+        var extractor = new CommandsExtractor();
+        extractor.Extract(ctx);
+        var items = extractor.Items;
+        Assert.Contains(items, i => i.Command == "/start" && i.Handler == "StartHandler");
+        Assert.Contains(items, i => i.Command == "/stats" && i.Handler == "StatsHandler");
+        Assert.Contains(items, i => i.Command == "/help" && i.Handler == null);
+        Assert.Contains(items, i => i.Command == "/about" && i.Handler == null);
+        Assert.Contains(items, i => i.Command == "/ban" && i.Handler == null);
+        // Sorted
+        var sorted = items.OrderBy(i => i.Command, StringComparer.Ordinal).ThenBy(i => i.Handler, StringComparer.Ordinal).ToList();
+        Assert.Equal(sorted.Select(x => x.Command+"|"+x.Handler), items.Select(x => x.Command+"|"+x.Handler));
+    }
+}

--- a/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp.sln
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp.sln
@@ -1,0 +1,6 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CmdApp", "CmdApp/CmdApp.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Global
+EndGlobal

--- a/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp/CmdApp.csproj
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp/CmdApp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp/Program.cs
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/CmdApp/CmdApp/Program.cs
@@ -1,0 +1,21 @@
+using System;
+
+public sealed class StartHandler {}
+public sealed class StatsHandler {}
+
+public static class RouterExtensions {
+  public static void Map(this object r, string cmd, object h) {}
+  public static void Register<T>(this object r, string cmd) {}
+}
+
+public class Program {
+  public static void Main() {
+    var router = new object();
+    router.Map("/start", new StartHandler());
+    router.Register<StatsHandler>("/stats");
+    var text = "/ignored"; // noise
+    if (text == "/help") { }
+    if (text.Equals("/about")) { }
+    if (text.StartsWith("/ban")) { }
+  }
+}

--- a/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp.sln
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp.sln
@@ -1,0 +1,6 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfApp", "ConfApp/ConfApp.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Global
+EndGlobal

--- a/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp/ConfApp.csproj
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp/ConfApp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp/Program.cs
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/ConfApp/ConfApp/Program.cs
@@ -1,0 +1,16 @@
+using System;
+
+public interface IAppConfig { string AdminChatId { get; } bool AiEnabled { get; } }
+public sealed class FeatureConfig { public string FeatureX { get; set; } = ""; }
+
+public class Program {
+  public static void Main() {
+    var k1 = Environment.GetEnvironmentVariable("DOORMAN_BOT_API");
+    var k2 = Environment.GetEnvironmentVariable("DOORMAN_LOG_ADMIN_CHAT");
+    IAppConfig cfg = default!;
+    var a = cfg.AdminChatId;
+    var b = cfg.AiEnabled;
+    FeatureConfig fcfg = default!;
+    var c = fcfg.FeatureX;
+  }
+}

--- a/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp.sln
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp.sln
@@ -1,0 +1,6 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlowApp", "FlowApp/FlowApp.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Global
+EndGlobal

--- a/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp/FlowApp.csproj
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp/FlowApp.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp/Program.cs
+++ b/tests/CdIndex.Extractors.Tests/TestAssets/FlowApp/FlowApp/Program.cs
@@ -1,0 +1,14 @@
+public sealed class MessageHandler {
+  public void HandleAsync() {
+    if (IsWhitelisted()) return;
+    if (IsDisabled()) return;
+    if (IsCommand()) { Router.Handle(); return; }
+    if (IsPrivate()) return;
+    if (HasNewMembers()) { JoinFacade.Handle(); return; }
+    ModerationService.Check();
+  }
+  bool IsWhitelisted()=>true; bool IsDisabled()=>false; bool IsCommand()=>false; bool IsPrivate()=>false; bool HasNewMembers()=>false;
+}
+public static class Router { public static void Handle() {} }
+public static class JoinFacade { public static void Handle() {} }
+public static class ModerationService { public static void Check() {} }


### PR DESCRIPTION
This PR implements and tests all three P1 extractors:

- #16 Config extractor (env keys + AppConfig properties)
- #17 Commands extractor (router registrations, comparison-based commands)
- #18 Flow extractor (message handler control flow)

**Features:**
- Model/schema v1.1: ProjectIndex extended with Configs, Commands, MessageFlow sections
- Extractors: ConfigExtractor, CommandsExtractor, FlowExtractor
- CLI flags: --scan-configs, --env-prefix, --scan-commands, --scan-flow, --flow-handler, --flow-method
- Test assets: ConfApp, CmdApp, FlowApp (added to repo)
- Unit tests: ConfigExtractorTests, CommandsExtractorTests, FlowExtractorTests
- CLI integration tests: ScanNewSectionsTests (validates all new sections)
- Deterministic output: sorted collections, repo-relative paths, forward slashes
- README updated with new flags and usage
- CI: all tests green, Windows paths normalized

**How to verify:**
- Run CLI with new flags on test assets (see README)
- Check output JSON for expected sections and sorting
- Run tests: all should pass

Closes #16, #17, #18
